### PR TITLE
Don't warn if already posted on Scrapbook

### DIFF
--- a/lib/api-utils.js
+++ b/lib/api-utils.js
@@ -259,6 +259,12 @@ export const updateExists = async (updateId) =>
     .then((r) => r.length > 0)
     .catch((err) => console.log('Cannot check if update exists', err))
 
+export const updateExistsTS = async (TS) =>
+  updatesTable
+    .read({ filterByFormula: `{Message Timestamp} = '${TS}'` })
+    .then((r) => r.length > 0)
+    .catch((err) => console.log('Cannot check if update exists', err))
+
 export const getEmojiRecord = async (reaction) => {
   if (reaction.includes('::')) {
     // This will only happen if a skin tone is applied. e.g :+1::skin-tone-5:. Remove the modifier.

--- a/pages/api/slack/message/reactionAdded.js
+++ b/pages/api/slack/message/reactionAdded.js
@@ -10,6 +10,7 @@ import {
   react,
   getMessage,
   t,
+  updateExistsTS,
   getPublicFileUrl,
   incrementStreakCount,
   formatText,
@@ -33,6 +34,9 @@ export default async (req, res) => {
   const { channel, ts } = item
 
   if (reaction !== 'aom' && user === 'U015D6A36AG') return
+  
+  if (await updateExistsTS(ts) && (reaction === 'scrappy' || reaction === 'scrappyparrot') &&
+    channel !== process.env.CHANNEL) return
 
   // If someone reacted with a Scrappy emoji in a non-#scrapbook channel, then maybe upload it.
   if (


### PR DESCRIPTION
This might make it so that doesn't happen when someone else has added the Scrappy react:

<img width="526" alt="Screenshot 2020-10-13 at 10 51 50 PM" src="https://user-images.githubusercontent.com/39828164/95877439-b0fc7780-0da6-11eb-85c1-b399e0e38218.png">

It will also fix if I unclick the Scrappy reaction, and then reclick it won't repost