### PR TITLE
add ABCO-1 as a keyword

### DIFF
--- a/src/lib/emojiKeywords.json
+++ b/src/lib/emojiKeywords.json
@@ -140,5 +140,6 @@
   "rick roll": "smolrick",
   "BrainDUMP": "braindump",
   "firefox": "firefoxlogo",
-  "vivaldi": "vivaldi"
+  "vivaldi": "vivaldi",
+  "ABCO-1": "abcout"
 }


### PR DESCRIPTION
i genuinely don't mind at all if this gets closed due to not being relevant enough, but this adds [ABCO-1](https://github.com/sporeball/ABCO-1) as an emoji keyword.\
out of all of my projects, i expect to be working on this one for the longest amount of time.