### PR TITLE
Don't change status when custom status exists

### DIFF
--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -143,7 +143,7 @@ export const displayStreaks = async (userId, streakCount) => {
   ).then((r) => r.json())
   
   if (user.profile["status_text"] || user.profile["status_emoji"]){ 
-    if (!user.profile["status_text"].startsWith("day streak in #scrapbook")return;
+    if (!user.profile["status_text"].startsWith("day streak in #scrapbook"))return;
   };
 
   if (!userRecord.streaksToggledOff) {

--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -141,6 +141,8 @@ export const displayStreaks = async (userId, streakCount) => {
       }
     }
   ).then((r) => r.json())
+  
+  if (user.profile["status_text"] || user.profile["status_emoji"])return;
 
   if (!userRecord.streaksToggledOff) {
     if (streakCount == 0 || !userRecord.displayStreak) {

--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -142,7 +142,9 @@ export const displayStreaks = async (userId, streakCount) => {
     }
   ).then((r) => r.json())
   
-  if (user.profile["status_text"] || user.profile["status_emoji"])return;
+  if (user.profile["status_text"] || user.profile["status_emoji"]){ 
+    if (!user.profile["status_text"].startsWith("day streak in #scrapbook")return;
+  };
 
   if (!userRecord.streaksToggledOff) {
     if (streakCount == 0 || !userRecord.displayStreak) {


### PR DESCRIPTION
Made the bot not change the user's status to scrapbook streak if the user already has a custom status