### PR TITLE
Add script to fix fullSlackMember user property

### DIFF
--- a/scripts/fixUserSlackMembership.js
+++ b/scripts/fixUserSlackMembership.js
@@ -1,0 +1,14 @@
+// This script fixes an issue where new Scrapbook accounts created after the Prisma migration (commit 48bc523) but before commit 9df84d1 were not assigned a fullSlackMember value.
+// Make sure to run `yarn run build` and have the PG_DATABASE_URL environment variable set before running this script.
+(async () => {
+    require('dotenv').config()
+    const { isFullMember } = require('../build/lib/api-utils.js');
+    const { PrismaClient } = require('@prisma/client')
+    let prisma = new PrismaClient()
+    const users = await prisma.accounts.findMany({where: { fullSlackMember: null }})
+    users.forEach(async (user) => {
+        if (await isFullMember(user)) {
+            prisma.accounts.update({where: { slackID: user.slackID }, data: { fullSlackMember: true }})
+        }
+    });
+})();

--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -8,11 +8,6 @@ import path from 'path'
 const yaml = require('js-yaml')
 import prisma from './prisma'
 
-const { Video } = new Mux(
-  process.env.MUX_TOKEN_ID,
-  process.env.MUX_TOKEN_SECRET
-)
-
 export const timeout = (ms) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -411,6 +406,11 @@ export const isNewMember = async (userId) => {
 }
 
 export const getPublicFileUrl = async (urlPrivate, channel, user) => {
+  const { Video } = new Mux(
+    process.env.MUX_TOKEN_ID,
+    process.env.MUX_TOKEN_SECRET
+  )
+  
   const fileName = urlPrivate.split('/').pop()
   const fileId = urlPrivate.split('-')[2].split('/')[0]
   console.log('file id', fileId)

--- a/src/lib/api-utils.js
+++ b/src/lib/api-utils.js
@@ -8,6 +8,11 @@ import path from 'path'
 const yaml = require('js-yaml')
 import prisma from './prisma'
 
+const { Video } = new Mux(
+  process.env.MUX_TOKEN_ID,
+  process.env.MUX_TOKEN_SECRET
+)
+
 export const timeout = (ms) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -406,11 +411,6 @@ export const isNewMember = async (userId) => {
 }
 
 export const getPublicFileUrl = async (urlPrivate, channel, user) => {
-  const { Video } = new Mux(
-    process.env.MUX_TOKEN_ID,
-    process.env.MUX_TOKEN_SECRET
-  )
-  
   const fileName = urlPrivate.split('/').pop()
   const fileId = urlPrivate.split('-')[2].split('/')[0]
   console.log('file id', fileId)


### PR DESCRIPTION
Someone with DB access would need to run this manually, but we should be good after running this once. It might also be worth updating the schema to make a few more properties non-optional (including `fullSlackMember`), thoughts?