### PR TITLE
Pin node-fetch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "node-fetch"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.19",
     "node-emoji": "^1.11.0",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "2.6.1"
   },
   "devDependencies": {
     "dotenv": "^10.0.0",


### PR DESCRIPTION
Let scrappy only use node-fetch v2.6.1; it seems like updating `node-fetch` tends to break scrappy.
