### PR TITLE
Delegate subdomains owned by other vercel accounts

### DIFF
--- a/src/api/slack/commands/setdomain.js
+++ b/src/api/slack/commands/setdomain.js
@@ -19,14 +19,6 @@ export default async (req, res) => {
   if (!arg) {
     sendCommandResponse(command.response_url, t('messages.domain.noargs'))
   } else {
-    const updates = await prisma.accounts.findMany({
-      where: {
-        customDomain: {
-          contains: '.'
-        }
-      }
-    })
-
     const user = await getUserRecord(command.user_id)
     if (user.customDomain != null) {
       console.log('DOMAIN ALREADY SET')
@@ -60,10 +52,48 @@ export default async (req, res) => {
         console.log(`Error while setting custom domain ${arg}: ${err}`)
       })
     console.log(vercelFetch)
-    if (vercelFetch.error) {
+    // domain is owned by another Vercel account, but we can request a delegation
+    if (vercelFetch.error?.code === 'forbidden') {
+      const delegationReq = await fetch(
+        `https://api.vercel.com/v6/domains/${arg}/request-delegation`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.VC_SCRAPBOOK_TOKEN}`
+          }
+        }
+      )
+        .then((r) => r.json())
+        .catch((err) => {
+          console.log(`Error while delegating custom domain ${arg}: ${err}`)
+        })
+
+      if (delegationReq.error) {
+        // something went wrong, such as the domain being an apex domain
+        sendCommandResponse(
+          command.response_url,
+          t('messages.domain.domainerror', {
+            text: arg,
+            error: delegationReq.error.message
+          })
+        )
+      } else {
+        // successfully requested delegation
+        sendCommandResponse(
+          command.response_url,
+          t('messages.domain.domaindelegated', {
+            text: arg
+          })
+        )
+      }
+    } else if (vercelFetch.error) {
       sendCommandResponse(
         command.response_url,
-        t('messages.domain.domainexists', { text: arg })
+        t('messages.domain.domainerror', {
+          text: arg,
+          error: vercelFetch.error.message
+        })
       )
     } else {
       await prisma.accounts.update({

--- a/src/lib/transcript.yml
+++ b/src/lib/transcript.yml
@@ -48,7 +48,7 @@ messages:
     6: 6 days! You've almost made it to a week!!! Don't stop now!!!! A week is 7 days by the way. ${this.scrapbookLink}
     7: |
       A WHOLE WEEK OF STREAKS?!?! https://www.youtube.com/watch?v=i0dmSIAzWeQ
-      
+
       ${this.scrapbookLink}
     '7+':
       - Yahoo! ${this.scrapbookLink}
@@ -66,8 +66,7 @@ messages:
       :yay::yay::yay: Your update is live on your scrapbook! :yay::yay::yay: ${this.scrapbookLink}
 
       (PS: you've already posted today, so I didn't increment your streak. But great job!)
-    newstreak:
-      ':yay: You just started a streak! Keep posting every day to continue your streak. In the meantime, type \`/scrappy help\` to see what else you can do!'
+    newstreak: ':yay: You just started a streak! Keep posting every day to continue your streak. In the meantime, type \`/scrappy help\` to see what else you can do!'
     oldmember:
       1: |
         Far out! You've started a new streak! Welcome back to Scrapbook :yay:
@@ -135,7 +134,8 @@ messages:
   domain:
     noargs: To link a custom domain to your scrapbook, type \`/scrappy-setdomain\` followed by the domain or subdomain you want to link. e.g. \`/scrappy-setdomain zachlatta.com\`. Then, create a CNAME record in your DNS provider for your domain and point it to \`cname.vercel-dns.com\`.
     overlimit: Couldn't set your domain. Only 50 custom domains can be added to a project, and 50 people have already added their custom domains. <https://hackclub.slack.com/archives/C0M8PUPU6/p1602535670075000|Here's an alternative>.
-    domainexists: Couldn't set your domain \`${this.text}\`. You can't add a domain if it's already set to another Vercel project. Try again with a different domain. <https://hackclub.slack.com/archives/C0M8PUPU6/p1602535670075000|Here's an alternative>.
+    domainerror: Couldn't set your domain \`${this.text}\`. Here's the error - \`${this.message}\`
+    domaindelegated: Your domain is owned by another Vercel account, so you'll need to approve the delegation request sent to your email, then run \`/scrappy-setdomain ${this.text}\` again.
     domainset: |
       Custom domain \`${this.text}\` set!
 
@@ -174,7 +174,7 @@ messages:
       files: |
         Hmm... :thonk: I don't detect any files in this message.
   mentionKeyword:
-    - <@${this.user}> no u 
+    - <@${this.user}> no u
     - <@${this.user}> :()
     - <@${this.user}> aosidjghlkj;LKasASDLKGJ AASDFLKJ LAKJSHDF ;OIHA GKLJRWHG AJSDGH
     - <@${this.user}> no u ${'!'.repeat(Math.floor(Math.random() * 7))}


### PR DESCRIPTION
Part 2 of trying to get my scrapbook subdomain working 😆 

[This API endpoint](https://vercel.notion.site/Preview-Requesting-Subdomain-Access-79df63d854b24a0abd52da991d50cb81) is technically in preview, but it's used in Vercel's [platforms example](https://github.com/vercel/platforms) so it probably won't change much.