### PR TITLE
Respond with entire error

### DIFF
--- a/src/api/slack/commands/setdomain.js
+++ b/src/api/slack/commands/setdomain.js
@@ -75,7 +75,7 @@ export default async (req, res) => {
           command.response_url,
           t('messages.domain.domainerror', {
             text: arg,
-            error: delegationReq.error.message
+            error: JSON.stringify(delegationReq.error)
           })
         )
       } else {
@@ -92,7 +92,7 @@ export default async (req, res) => {
         command.response_url,
         t('messages.domain.domainerror', {
           text: arg,
-          error: vercelFetch.error.message
+          error: JSON.stringify(vercelFetch.error)
         })
       )
     } else {


### PR DESCRIPTION
I tried adding a subdomain and it delegated successfully, but errored with an`undefined` error message when I ran the command again. Hopefully having the entire error will make it easier to debug?