### PR TITLE
Update README for dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ![build](https://github.com/hackclub/scrappy/workflows/build/badge.svg)
 
-The Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com).
+Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy automatically generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up,
+
+[Click here to view the Scrapbook repository](https://github.com/hackclub/scrapbook), which hosts the Scrapbook web code.
 
 ## Commands
-Scrappy not only handles the automatic generation of a Scrapbook and its posts, but provides some helpful commands in Slack as well. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
+Scrappy provides some helpful commands in Slack. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
 
 - `/scrappy-togglestreaks`: toggles your streak count on/off in your status
 - `/scrappy-togglestreaks all`: opts out of streaks completely
@@ -19,19 +21,18 @@ Scrappy not only handles the automatic generation of a Scrapbook and its posts, 
 - *Remove* a post: delete the Slack message and Scrappy will automatically update for you
 - *Edit* a post: edit the Slack message and it will automatically update for you
 
-
 ## Contributing
 
 Contributions are encouraged and welcome! There are two GitHub repositories that contain code for Scrapbook: the [Scrapbook website](https://github.com/hackclub/scrapbook#contributing) and [Scrappy the Slack bot](https://github.com/hackclub/scrappy#contributing). Each repository has a section on contributing guidelines and how to run each project locally.
 
-Development chatter happens in the [#scrapbook-dev](https://app.slack.com/client/T0266FRGM/C035D6S6TFW) channel in the [Hack Club Slack](https://hackclub.com/slack/).
+Development chatter happens in the [#scrappy-dev](https://app.slack.com/client/T0266FRGM/C01NQTDFUR5) channel in the [Hack Club Slack](https://hackclub.com/slack/).
 
 ## Running locally
 In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). From there, ask @sampoder to be added to the `scrappy (dev)` app on Slack.
 
 1. Clone this repository
    - `git clone https://github.com/hackclub/scrappy.git && cd scrappy`
-1. Install [ngrok](https://dashboard.ngrok.com/get-started/setup)
+1. Install [ngrok](https://dashboard.ngrok.com/get-started/setup) (if you haven't already)
    - Recommended installation is via [Homebrew](https://brew.sh/)
    - `brew install ngrok`
 1. Install dependencies
@@ -39,7 +40,23 @@ In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https
 1. Create `.env` file at root of project
    - `touch .env`
    - Ask `@sampoder` for the `.env` file contents
+1. Link your `.env` with your prisma schema
+   `npx prisma generate`
 1. Start server
    - `yarn dev`
 1. Forward your local server to ngrok
    - `ngrok http 3000`
+
+Those with access to HQ's Heroku account can also create their own `.env` file:
+
+- Install Heroku's CLI (if you haven't already)
+   - `brew install heroku`
+- Link Heroku to your account
+   - `heroku login`
+- View environment variables from Heroku
+   - `heroku config --app scrappy-hackclub`
+- Copy these into your `.env` file, formatted like:
+```
+  PG_DATABASE_URL="insert value here"
+  SLACK_BOT_TOKEN="insert value here"
+```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https
 1. Update the [Slack settings](https://api.slack.com/apps/A015DCRTT43/event-subscriptions?)
    - Click the toggle to enable events
    - Update the URL request URL to be `<your-ngrok-url>/api/slack/message`. An example would look like `https://ea61-73-68-194-110.ngrok.io/api/slack/message`
+   - Save changes and reinstall the Slack app
+   - This will regenerate Scrappy's [oauth](https://api.slack.com/apps/A015DCRTT43/oauth?) tokens, so make sure to update these in the .env

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Development chatter happens in the [#scrapbook-dev](https://app.slack.com/client
 In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). To get started developing, ask @sampoder to be added to the `scrappy (dev)` app on Slack and for a `.env` file.
 
 1. Clone this repository
-   - `git clone https://github.com/hackclub/scrapbook.git && cd scrapbook`
+   - `git clone https://github.com/hackclub/scrappy.git && cd scrappy`
 1. Install dependencies
    - `yarn`
 1. Ask `@sampoder` for the `.env` file

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Scrappy provides some helpful commands in Slack. These commands are also documen
 
 ## Contributing
 
-Contributions are encouraged and welcome! There are two GitHub repositories that contain code for Scrapbook: the [Scrapbook website](https://github.com/hackclub/scrapbook#contributing) and [Scrappy the Slack bot](https://github.com/hackclub/scrappy#contributing). Each repository has a section on contributing guidelines and how to run each project locally.
+Contributions are encouraged and welcome! There are two GitHub repositories that contain code for Scrapbook: the [Scrapbook website](https://github.com/hackclub/scrapbook#contributing) and [Scrappy (the Slack bot)](https://github.com/hackclub/scrappy#contributing). Each repository has a section on contributing guidelines and how to run each project locally.
 
 Development chatter happens in the [#scrapbook-dev](https://app.slack.com/client/T0266FRGM/C035D6S6TFW) channel in the [Hack Club Slack](https://hackclub.com/slack/). Development Scrappy posts happen in the [#scrappy-dev](https://app.slack.com/client/T0266FRGM/C01NQTDFUR5) channel.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![build](https://github.com/hackclub/scrappy/workflows/build/badge.svg)
 
-Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up for Scrapbook, check out the [about page]([scrapbook.hackclub.com](https://scrapbook.hackclub.com).
+Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up for Scrapbook, check out the [about page](https://scrapbook.hackclub.com/about).
 
 [Click here to view the Scrapbook repository](https://github.com/hackclub/scrapbook), which hosts the Scrapbook web code.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scrappy the Slack Bot
+# Scrappy
 
 ![build](https://github.com/hackclub/scrappy/workflows/build/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![build](https://github.com/hackclub/scrappy/workflows/build/badge.svg)
 
-Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up,
+Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up for Scrapbook, check out the [about page]([scrapbook.hackclub.com](https://scrapbook.hackclub.com).
 
 [Click here to view the Scrapbook repository](https://github.com/hackclub/scrapbook), which hosts the Scrapbook web code.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Scrappy provides some helpful commands in Slack. These commands are also documen
 
 Contributions are encouraged and welcome! There are two GitHub repositories that contain code for Scrapbook: the [Scrapbook website](https://github.com/hackclub/scrapbook#contributing) and [Scrappy the Slack bot](https://github.com/hackclub/scrappy#contributing). Each repository has a section on contributing guidelines and how to run each project locally.
 
-Development chatter happens in the [#scrappy-dev](https://app.slack.com/client/T0266FRGM/C01NQTDFUR5) channel in the [Hack Club Slack](https://hackclub.com/slack/).
+Development chatter happens in the [#scrapbook-dev](https://app.slack.com/client/T0266FRGM/C035D6S6TFW) channel in the [Hack Club Slack](https://hackclub.com/slack/). Development Scrappy posts happen in the [#scrappy-dev](https://app.slack.com/client/T0266FRGM/C01NQTDFUR5) channel.
 
 ## Running locally
 In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). From there, ask @sampoder to be added to the `scrappy (dev)` app on Slack.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Scrappy provides some helpful commands in Slack. These commands are also documen
 - `/scrappy-webring`: adds or removes someone to your webring
 - *Remove* a post: delete the Slack message and Scrappy will automatically update for you
 - *Edit* a post: edit the Slack message and it will automatically update for you
-- *Post* an existing Slack message to Scrapbook by reacting to it with the `:scrappy:` emoji (Note: If it isn't working, make sure Scrappy is added to the channel by mentioning `@scrappy`)
+- *Post* a message to the `#scrapbook` channel or add an existing Slack message to Scrapbook by reacting to it with the `:scrappy:` emoji (Note: If it isn't working, make sure Scrappy is added to the channel by mentioning `@scrappy`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Scrappy provides some helpful commands in Slack. These commands are also documen
 - `/scrappy-webring`: adds or removes someone to your webring
 - *Remove* a post: delete the Slack message and Scrappy will automatically update for you
 - *Edit* a post: edit the Slack message and it will automatically update for you
+- *Post* an existing Slack message to Scrapbook by reacting to it with the `:scrappy:` emoji (Note: If it isn't working, make sure Scrappy is added to the channel by mentioning `@scrappy`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -40,23 +40,13 @@ In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https
 1. Create `.env` file at root of project
    - `touch .env`
    - Ask `@sampoder` for the `.env` file contents
-1. Link your `.env` with your prisma schema
+1. Link your `.env` with your Prisma schema
    `npx prisma generate`
 1. Start server
    - `yarn dev`
 1. Forward your local server to ngrok
    - `ngrok http 3000`
-
-Those with access to HQ's Heroku account can also create their own `.env` file:
-
-- Install Heroku's CLI (if you haven't already)
-   - `brew install heroku`
-- Link Heroku to your account
-   - `heroku login`
-- View environment variables from Heroku
-   - `heroku config --app scrappy-hackclub`
-- Copy these into your `.env` file, formatted like:
-```
-  PG_DATABASE_URL="insert value here"
-  SLACK_BOT_TOKEN="insert value here"
-```
+   - Your ngrok URL will be printed out after running this command, which you will need for the next step
+1. Update the [Slack settings](https://api.slack.com/apps/A015DCRTT43/event-subscriptions?)
+   - Click the toggle to enable events
+   - Update the URL request URL to be `<your-ngrok-url>/api/slack/message`. An example would look like `https://ea61-73-68-194-110.ngrok.io/api/slack/message`

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https
    - `touch .env`
    - Ask `@sampoder` for the `.env` file contents
 1. Link your `.env` with your Prisma schema
-   `npx prisma generate`
+   - `npx prisma generate`
 1. Start server
    - `yarn dev`
 1. Forward your local server to ngrok

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![build](https://github.com/hackclub/scrappy/workflows/build/badge.svg)
 
-Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy automatically generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up,
+Scrappy is the Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). Scrappy generates your Scrapbook and Scrapbook posts via Slack messages. For more information about how to sign up,
 
 [Click here to view the Scrapbook repository](https://github.com/hackclub/scrapbook), which hosts the Scrapbook web code.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
-# scrappy
+# Scrappy the Slack Bot
 
 ![build](https://github.com/hackclub/scrappy/workflows/build/badge.svg)
 
-the slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com). to get started developing, ask @sampoder to be added to the `scrappy (dev)` app on Slack and for a `.env` file. then use `ngrok` to forward your local instance onto the world wide web.
+The Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com).
+
+## Commands
+Scrappy not only handles the automatic generation of things, but provides some helpful commands as well. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
+
+- `/scrappy-togglestreaks`: toggles your streak count on/off in your status
+- `/scrappy-togglestreaks all`: opts out of streaks completely
+- `/scrappy-open`: opens your scrapbook (or another user's if you specify a username)
+- `/scrappy-setcss`: adds a custom CSS file to your scrapbook profile. Check out this cool example!
+- `/scrappy-setdomain`: links a custom domain to your scrapbook profile, e.g. [https://zachlatta.com](https://zachlatta.com)
+- `/scrappy-setusername`: change your profile username
+- `/scrappy-setaudio`: links an audio file to your Scrapbook. [See an example here](https://scrapbook.hackclub.com/matthew)!
+- `/scrappy-setwebhook`: create a Scrappy Webhook we will make a blank fetch request to this URL every time you post
+- `/scrappy-webring`: adds or removes someone to your webring
+- *Remove* a post: delete the Slack message and Scrappy will automatically update for you
+- *Edit* a post: edit the Slack message and it will automatically update for you
+
+
+## Contributing
+
+Contributions are encouraged and welcome! There are two GitHub repositories that contain code for Scrapbook: the [Scrapbook website](https://github.com/hackclub/scrapbook#contributing) and [Scrappy the Slack bot](https://github.com/hackclub/scrappy#contributing). Each repository has a section on contributing guidelines and how to run each project locally.
+
+Development chatter happens in the [#scrapbook-dev](https://app.slack.com/client/T0266FRGM/C035D6S6TFW) channel in the [Hack Club Slack](https://hackclub.com/slack/).
+
+## Running locally
+In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). To get started developing, ask @sampoder to be added to the `scrappy (dev)` app on Slack and for a `.env` file.
+
+1. Clone this repository
+   - `git clone https://github.com/hackclub/scrapbook.git && cd scrapbook`
+1. Install dependencies
+   - `yarn`
+1. Ask `@sampoder` for the `.env` file
+1. Start server
+   - `yarn dev`
+1. View your server
+   - `open http://localhost:3000/`
+
+then use `ngrok` to forward your local instance onto the world wide web.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The Slack bot that powers [scrapbook.hackclub.com](https://scrapbook.hackclub.com).
 
 ## Commands
-Scrappy not only handles the automatic generation of things, but provides some helpful commands as well. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
+Scrappy not only handles the automatic generation of a Scrapbook and its posts, but provides some helpful commands in Slack as well. These commands are also documented in our Slack if you send the message `/scrappy` in any channel.
 
 - `/scrappy-togglestreaks`: toggles your streak count on/off in your status
 - `/scrappy-togglestreaks all`: opts out of streaks completely
@@ -27,20 +27,19 @@ Contributions are encouraged and welcome! There are two GitHub repositories that
 Development chatter happens in the [#scrapbook-dev](https://app.slack.com/client/T0266FRGM/C035D6S6TFW) channel in the [Hack Club Slack](https://hackclub.com/slack/).
 
 ## Running locally
-In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). To get started developing, ask @sampoder to be added to the `scrappy (dev)` app on Slack and for a `.env` file.
+In order to run Scrappy locally, you'll need to [join the Hack Club Slack](https://hackclub.com/slack). From there, ask @sampoder to be added to the `scrappy (dev)` app on Slack.
 
 1. Clone this repository
    - `git clone https://github.com/hackclub/scrappy.git && cd scrappy`
+1. Install [ngrok](https://dashboard.ngrok.com/get-started/setup)
+   - Recommended installation is via [Homebrew](https://brew.sh/)
+   - `brew install ngrok`
 1. Install dependencies
    - `yarn`
-1. Ask `@sampoder` for the `.env` file
+1. Create `.env` file at root of project
+   - `touch .env`
+   - Ask `@sampoder` for the `.env` file contents
 1. Start server
    - `yarn dev`
-1. View your server
-   - `open http://localhost:3000/`
-
-then use `ngrok` to forward your local instance onto the world wide web.
-
----
-
-[learn more about how to get started](https://scrapbook.hackclub.com/about)
+1. Forward your local server to ngrok
+   - `ngrok http 3000`


### PR DESCRIPTION
Add some docs and dev instructions to README. As a note, bots are kinda confusing to get running locally! 😵‍💫 As @sampoder said, the easiest way to update Scrappy is by pushing to `main` and letting it deploy.

Fixes https://github.com/hackclub/scrappy/issues/311.