### PR TITLE
Remove #scrapbook from channelKeywords

### DIFF
--- a/src/lib/channelKeywords.js
+++ b/src/lib/channelKeywords.js
@@ -15,7 +15,6 @@ export default {
   "C019RMWTECD": "ussr",
   "CDLBHGUQN": "cat", // #cats
   "CDJV1CXC2": "dog", // #dogs
-  "C01504DCLVD": "scrappy", // #scrapbook
   "C01NQTDFUR5": "scrappy", // #scrappy-dev
   "C02TWKX227J": "wordle",
   "C0P5NE354": "robot_face", // #bot-spam


### PR DESCRIPTION
I noticed that scrappy was reacting to all the #scrapbook posts with the :scrappy: emoji, so I believe I initially misunderstood the purpose of `channelKeywords`. 

I thought it was the same as `emojiKeywords` but with channel IDs. However it seems like Scrappy reacts with the respective emoji if the post is scrapbooked from the specified channel.

This PR fixes that, so scrappy stops reacting to every single post with :scrappy:!