### PR TITLE
New domain verification flow

### DIFF
--- a/src/lib/transcript.yml
+++ b/src/lib/transcript.yml
@@ -137,7 +137,10 @@ messages:
     noargs: To link a custom domain to your scrapbook, type \`/scrappy-setdomain\` followed by the domain or subdomain you want to link. e.g. \`/scrappy-setdomain zachlatta.com\`. Then, create a CNAME record in your DNS provider for your domain and point it to \`cname.vercel-dns.com\`.
     overlimit: Couldn't set your domain. Only 50 custom domains can be added to a project, and 50 people have already added their custom domains. <https://hackclub.slack.com/archives/C0M8PUPU6/p1602535670075000|Here's an alternative>.
     domainerror: Couldn't set your domain \`${this.text}\`. Here's the error - \`${this.error}\`
-    domaindelegated: Your domain is owned by another Vercel account, so you'll need to approve the delegation request sent to your email, then run \`/scrappy-setdomain ${this.text}\` again.
+    domainverify: |
+      Your domain is owned by another Vercel account, so you'll need to verify the domain by adding the following DNS record
+
+      ${this.text}
     domainset: |
       Custom domain \`${this.text}\` set!
 


### PR DESCRIPTION
Vercel now allows domains to be used across multiple accounts by adding a `TXT` record for [verification](https://vercel.com/docs/rest-api#endpoints/projects/add-a-domain-to-a-project). The old flow has been [deprecated](https://vercel.notion.site/Preview-Requesting-Subdomain-Access-79df63d854b24a0abd52da991d50cb81)

I didn't test this yet, but I can later (school seems to block tunnels)