### PR TITLE
Change summer emoji

### DIFF
--- a/src/lib/seasonEmoji.js
+++ b/src/lib/seasonEmoji.js
@@ -6,7 +6,7 @@ export const SEASON_EMOJI =
   seasonNorth(new Date()) == "Spring"
     ? "spring-of-making"
     : seasonNorth(new Date()) == "Summer"
-    ? "summer-of-making"
+    ? "summer-making"
     : seasonNorth(new Date()) == "Winter"
     ? "wom"
     : "aom";


### PR DESCRIPTION
This PR changes the summer emoji to "summer-making" instead of "summer-of-making" because the Summer of Making scrapbook page appears to be an archive of the actual 2022 Summer of Making event https://scrapbook.hackclub.com/r/summer-of-making

(summer-making isn't the greatest name; open to suggestions if anyone has a better name)