### PR TITLE
Patched CVE-2022-0235 node-fetch

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,8 +1302,8 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@2.6.1:
-  version "2.6.1"
+node-fetch@2.6.7:
+  version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 


### PR DESCRIPTION
node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor