### PR TITLE
feat: do not post thread reply if it was reacted with scrappy-retry

### DIFF
--- a/src/events/reactionAdded.js
+++ b/src/events/reactionAdded.js
@@ -58,7 +58,7 @@ export default async ({ event }) => {
   if (
     reaction === "scrappy-retry" &&
     channel == process.env.CHANNEL &&
-    message
+    message && !message.thread_ts
   ) {
     if (!message.files || message.files.length == 0) {
       postEphemeral(channel, t("messages.errors.anywhere.files"), user);


### PR DESCRIPTION
Prevent Scrappy from sending a scrapbook update if it received a scrappy-retry reaction AND it is a reply to a thread