### PR TITLE
retroactively add reactions when a post is scrapbooked

### DIFF
--- a/src/events/reactionAdded.js
+++ b/src/events/reactionAdded.js
@@ -51,7 +51,20 @@ export default async ({ event }) => {
         postEphemeral(channel, t("messages.errors.anywhere.files"), user);
         return;
       }
-      await createUpdate(message.files, channel, ts, user, message.text);
+      const update = await createUpdate(message.files, channel, ts, user, message.text);
+      message.reactions.forEach(async reaction => {
+        if (
+          reaction.name === "scrappy" ||
+          reaction.name === "scrappy-retry" ||
+          reaction.name === "scrappyparrot"
+        ) return;
+        await prisma.emojiReactions.create({
+          data: {
+            updateId: update.id,
+            emojiTypeName: reaction.name
+          }
+        });
+      });
     }
     return;
   }

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -61,7 +61,7 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
   const convertedDate = new Date(date).toISOString();
   const messageText = await formatText(text);
 
-  await prisma.updates.create({
+  const update = await prisma.updates.create({
     data: {
       accountsID: userRecord.id,
       accountsSlackID: userRecord.slackID,
@@ -80,6 +80,7 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
 
   metrics.increment("new_post", 1);
   await incrementStreakCount(user, channel, messageText, ts);
+  return update;
 };
 
 export const updateExists = async (updateId) =>


### PR DESCRIPTION
Previously scrappy will not add existing reactions when an old post is scrapbooked.
This change enables scrappy to add these reactions to the scrapbook post.

tackles #110 