### PR TITLE
prepend commands with `test-` if on staging environment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .env
 dist
 build
+production.env
+staging.env

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ import forget from "./events/forget.js";
 import noFile, { noFileCheck } from "./events/noFile.js";
 import reactionAdded from "./events/reactionAdded.js";
 import reactionRemoved from "./events/reactionAdded.js";
+import { commands } from "./commands/commands.js";
 import metrics from "./metrics.js";
 
 const receiver = new ExpressReceiver({
@@ -68,23 +69,23 @@ export const execute = (actionToExecute) => {
   };
 };
 
-app.command("/scrappy", execute(help));
+app.command(`/${commands.scrappy}`, execute(help));
 
-app.command("/scrappy-help", execute(help));
+app.command(`/${commands.scrappyHelp}`, execute(help));
 
-app.command("/scrappy-setaudio", execute(setAudio));
+app.command(`/${commands.scrappySetAudio}`, execute(setAudio));
 
-app.command("/scrappy-setcss", execute(setCSS));
+app.command(`/${commands.scrappySetCSS}`, execute(setCSS));
 
-app.command("/scrappy-setdomain", execute(setDomain));
+app.command(`/${commands.scrappySetDomain}`, execute(setDomain));
 
-app.command("/scrappy-displaystreaks", execute(toggleStreaks));
+app.command(`/${commands.scrappyDisplayStreaks}`, execute(toggleStreaks));
 
-app.command("/scrappy-setusername", execute(setUsername));
+app.command(`/${commands.scrappySetUsername}`, execute(setUsername));
 
-app.command("/scrappy-togglestreaks", execute(toggleStreaks));
+app.command(`/${commands.scrappyToggleStreaks}`, execute(toggleStreaks));
 
-app.command("/scrappy-webring", execute(webring));
+app.command(`/${commands.scrappyWebring}`, execute(webring));
 
 app.event("reaction_added", execute(reactionAdded));
 

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,0 +1,22 @@
+
+let commands = {
+    scrappy: "scrappy", // command | reaction 
+    scrappyRetryReaction: "scrappy-retry", 
+    scrappyParrotReaction: "scrappyparrot",
+    scrappyHelp: "scrappy-help",
+    scrappySetAudio: "scrappy-setaudio",
+    scrappySetCSS: "scrappy-setcss",
+    scrappySetDomain: "scrappy-setdomain",
+    scrappyDisplayStreaks: "scrappy-displaystreaks",
+    scrappySetUsername: "scrappy-setusername",
+    scrappyToggleStreaks: "scrappy-togglestreaks",
+    scrappyWebring: "scrappy-webring"
+};
+
+if (process.env.NODE_ENV === "staging") {
+    for (let key of Object.keys(commands)) {
+        commands[key] = "test-" + commands[key];
+    }
+}
+
+export { commands };

--- a/src/events/reactionAdded.js
+++ b/src/events/reactionAdded.js
@@ -11,6 +11,7 @@ import Bottleneck from "bottleneck";
 const limiter = new Bottleneck({ maxConcurrent: 1 });
 import channelKeywords from "../lib/channelKeywords.js";
 import clubEmojis from "../lib/clubEmojis.js";
+import { commands } from "../commands/commands.js";
 
 export default async ({ event }) => {
   const { item, user, reaction, item_user } = event;
@@ -21,12 +22,12 @@ export default async ({ event }) => {
   if (reaction !== SEASON_EMOJI && user === "U015D6A36AG") return;
   if (
     (await updateExistsTS(ts)) &&
-    (reaction === "scrappy" || reaction === "scrappyparrot") &&
+    (reaction === commands.scrappy || reaction === "scrappyparrot") &&
     channel !== process.env.CHANNEL
   )
     return;
   const message = await getMessage(ts, channel);
-  if ((await updateExistsTS(ts)) && reaction === "scrappy-retry") {
+  if ((await updateExistsTS(ts)) && reaction === commands.scrappyRetryReaction) {
     if (channelKeywords[channel])
       await react("add", channel, ts, channelKeywords[channel]);
     await reactBasedOnKeywords(channel, message.text, ts);
@@ -36,7 +37,7 @@ export default async ({ event }) => {
   }
   // If someone reacted with a Scrappy emoji in a non-#scrapbook channel, then maybe upload it.
   if (
-    (reaction === "scrappy" || reaction === "scrappyparrot") &&
+    (reaction === commands.scrappy || reaction === "scrappyparrot") &&
     channel !== process.env.CHANNEL
   ) {
     if (item_user != user) {
@@ -69,7 +70,7 @@ export default async ({ event }) => {
     return;
   }
   if (
-    reaction === "scrappy-retry" &&
+    reaction === commands.scrappyRetryReaction &&
     channel == process.env.CHANNEL &&
     message && !message.thread_ts
   ) {

--- a/src/lib/transcript.yml
+++ b/src/lib/transcript.yml
@@ -20,6 +20,7 @@ messages:
     BTW if you want to delete or update a post you can do so by simply editing or deleting your Slack message.
 
     Learn all about Scrapbook at https://scrapbook.hackclub.com/about
+    PS: prepend the commands with ´test-` if you're using the staging bot
   forget: |
     Forgetting about all recorded scraps from....
     uhhhh....


### PR DESCRIPTION
This enables us to separate commands/reactions to have a `test-` prepended to them to denote staging.

This change also adds a hint message when running `/[test-]scrappy` command in slack