### PR TITLE
Fix error conditions for invalid files

### DIFF
--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -20,17 +20,12 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
         await reply(channel, ts, t("messages.errors.filetype"))
         return;
       } else if (publicUrl.url.toLowerCase().endsWith("heic")) {
-        await Promise.all([
-          postEphemeral(channel, t("messages.errors.heic"), user),
-          app.client.chat.delete({
-            token: process.env.SLACK_USER_TOKEN,
-            channel,
-            ts,
-          }),
+        await postEphemeral(channel, t("messages.errors.heic"), user)
         ]);
         return;
       } else if (publicUrl.url === "big boy") {
         await Promise.all([
+          react("remove", channel, ts, "beachball"),
           reply(channel, ts, t("messages.errors.bigimage")),
         ]);
       }

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -17,17 +17,11 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
     ...files.map(async (file) => {
       const publicUrl = await getPublicFileUrl(file.url_private, channel, user);
       if (!publicUrl) {
-        await reply(channel, ts, t("messages.errors.filetype"))
+        await postEphemeral(channel, ts, t("messages.errors.filetype"), user)
         return;
       } else if (publicUrl.url.toLowerCase().endsWith("heic")) {
-        await postEphemeral(channel, t("messages.errors.heic"), user)
-        ]);
+        await postEphemeral(channel, t("messages.errors.heic"), user);
         return;
-      } else if (publicUrl.url === "big boy") {
-        await Promise.all([
-          react("remove", channel, ts, "beachball"),
-          reply(channel, ts, t("messages.errors.bigimage")),
-        ]);
       }
       attachments.push(publicUrl.url);
       if (publicUrl.muxId) {


### PR DESCRIPTION
@grymmy Can you test this please? I don't have a dev setup for scrappy. Hopefully this fix makes scrappy's behavior more intuitive. Now if you reaction scrapbook a message with one picture and 5 PDFs, it should scrapbook that one picture.

Pre: Whenever the first file was an invalid type or non existent, scrappy would react with an x, and stop processing.
Post: Invalid attachments are ignored. If there are 0 valid attachments, scrappy refuses to process and reacts with an x.

Both: Scrappy replies with a message for every wrong attachment describing why it was ignored.

Closes #493
