### PR TITLE
fix issue where Scrappy crashes when attempting to upload a video

### DIFF
--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -8,10 +8,10 @@ import { v4 as uuidv4 } from "uuid";
 import fetch from "node-fetch";
 import FormData from "form-data";
 
-const { Video } = new Mux(
-  process.env.MUX_TOKEN_ID,
-  process.env.MUX_TOKEN_SECRET
-);
+const mux = new Mux({
+  tokenId: process.env.MUX_TOKEN_ID,
+  tokenSecret: process.env.MUX_TOKEN_SECRET
+});
 
 const isFileType = (types, fileName) =>
   types.some((el) => fileName.toLowerCase().endsWith(el));
@@ -40,7 +40,7 @@ export const getPublicFileUrl = async (urlPrivate, channel, user) => {
     if (isVideo) {
       postEphemeral(channel, t("messages.errors.bigvideo"), user);
       await timeout(30000);
-      const asset = await Video.Assets.create({
+      const asset = await mux.video.assets.create({
         input: directUrl,
         playback_policy: "public",
       });
@@ -64,7 +64,8 @@ export const getPublicFileUrl = async (urlPrivate, channel, user) => {
       method: "POST",
       body: form,
     }).then((r) => r.text());
-    const asset = await Video.Assets.create({
+    console.log(Video);
+    const asset = await mux.video.assets.create({
       input: uploadedUrl,
       playback_policy: "public",
     });

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -64,7 +64,6 @@ export const getPublicFileUrl = async (urlPrivate, channel, user) => {
       method: "POST",
       body: form,
     }).then((r) => r.text());
-    console.log(Video);
     const asset = await mux.video.assets.create({
       input: uploadedUrl,
       playback_policy: "public",


### PR DESCRIPTION
scrappy would crash when attempting to upload a video because Mux was incorrectly instantiated

```
2024-03-21T15:57:54.796382+00:00 app[web.1]: file:///app/src/lib/files.js:67
2024-03-21T15:57:54.796461+00:00 app[web.1]: const asset = await Video.Assets.create({
2024-03-21T15:57:54.796461+00:00 app[web.1]: ^
2024-03-21T15:57:54.796463+00:00 app[web.1]: 
2024-03-21T15:57:54.796464+00:00 app[web.1]: TypeError: Cannot read properties of undefined (reading 'Assets')
2024-03-21T15:57:54.796466+00:00 app[web.1]: at getPublicFileUrl (file:///app/src/lib/files.js:67:31)
2024-03-21T15:57:54.796467+00:00 app[web.1]: at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-03-21T15:57:54.796467+00:00 app[web.1]: at async file:///app/src/lib/updates.js:18:25
2024-03-21T15:57:54.796467+00:00 app[web.1]: at async Promise.all (index 2)
2024-03-21T15:57:54.796468+00:00 app[web.1]: at async createUpdate (file:///app/src/lib/updates.js:15:18)
2024-03-21T15:57:54.796468+00:00 app[web.1]: at async default (file:///app/src/events/reactionAdded.js:81:5)
2024-03-21T15:57:54.796469+00:00 app[web.1]: 
2024-03-21T15:57:54.796470+00:00 app[web.1]: Node.js v18.19.1
2024-03-21T15:57:54.826026+00:00 app[web.1]: npm notice
2024-03-21T15:57:54.826149+00:00 app[web.1]: npm notice New minor version of npm available! 10.2.4 -> 10.5.0
2024-03-21T15:57:54.826192+00:00 app[web.1]: npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.5.0>
2024-03-21T15:57:54.826283+00:00 app[web.1]: npm notice Run `npm install -g npm@10.5.0` to update!
2024-03-21T15:57:54.826306+00:00 app[web.1]: npm notice
2024-03-21T15:57:54.920492+00:00 heroku[web.1]: Process exited with status 1
```

