### PR TITLE
fix running `/scrappy` command 

### DIFF
--- a/src/lib/transcript.js
+++ b/src/lib/transcript.js
@@ -37,6 +37,7 @@ const evalTranscript = (target, vars = {}) => {
     t,
   };
   return function () {
+    console.log("Target = ", target);
     return eval("`" + target + "`");
   }.call(context);
 };

--- a/src/lib/transcript.js
+++ b/src/lib/transcript.js
@@ -37,7 +37,6 @@ const evalTranscript = (target, vars = {}) => {
     t,
   };
   return function () {
-    console.log("Target = ", target);
     return eval("`" + target + "`");
   }.call(context);
 };

--- a/src/lib/transcript.yml
+++ b/src/lib/transcript.yml
@@ -20,7 +20,7 @@ messages:
     BTW if you want to delete or update a post you can do so by simply editing or deleting your Slack message.
 
     Learn all about Scrapbook at https://scrapbook.hackclub.com/about
-    PS: for scrappy_dev, prepend the commands with \´test-\` e.g \`\\test-scrappy\`
+    PS: for scrappy_dev, prepend the commands with \`test-\` e.g \`/test-scrappy\`
   forget: |
     Forgetting about all recorded scraps from....
     uhhhh....

--- a/src/lib/transcript.yml
+++ b/src/lib/transcript.yml
@@ -20,7 +20,7 @@ messages:
     BTW if you want to delete or update a post you can do so by simply editing or deleting your Slack message.
 
     Learn all about Scrapbook at https://scrapbook.hackclub.com/about
-    PS: prepend the commands with ´test-` if you're using the staging bot
+    PS: for scrappy_dev, prepend the commands with \´test-\` e.g \`\\test-scrappy\`
   forget: |
     Forgetting about all recorded scraps from....
     uhhhh....


### PR DESCRIPTION
fix running /scrappy command on slack.
previously, scrappy would crash because there was an if block in the help message which was misinterpreted by `eval()` when evaluating the transcript file. 

The message has been updated so scrappy would no longer crash when the help command is executed.