### PR TITLE
allow other services to subscribe to scrapbook updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mux/mux-node": "^8.7.1",
     "@prisma/client": "5.14.0",
     "@slack/bolt": "^3.18.0",
+    "airtable": "^0.12.2",
     "airtable-plus": "^1.0.4",
     "aws-sdk": "^2.1637.0",
     "bottleneck": "^2.19.5",

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -97,6 +97,28 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
     channel
   };
 
+ 
+
+  const update = await prisma.updates.create({
+    data: {
+      accountsID: userRecord.id,
+      accountsSlackID: userRecord.slackID,
+      postTime: convertedDate,
+      messageTimestamp: parseFloat(ts),
+      text: messageText,
+      attachments: attachments,
+      muxAssetIDs: videos,
+      muxPlaybackIDs: videoPlaybackIds,
+      isLargeVideo: attachments.some(
+        (attachment) => attachment.url === "https://i.imgur.com/UkXMexG.mp4"
+      ),
+      channel: channel,
+    },
+  });
+
+  metrics.increment("new_post", 1);
+  await incrementStreakCount(user, channel, messageText, ts);
+
   // send a copy of the updates to the subcribers
   base("Update Listeners").select({
     maxRecords: 100,
@@ -120,25 +142,6 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
     nextPage();
   });
 
-  const update = await prisma.updates.create({
-    data: {
-      accountsID: userRecord.id,
-      accountsSlackID: userRecord.slackID,
-      postTime: convertedDate,
-      messageTimestamp: parseFloat(ts),
-      text: messageText,
-      attachments: attachments,
-      muxAssetIDs: videos,
-      muxPlaybackIDs: videoPlaybackIds,
-      isLargeVideo: attachments.some(
-        (attachment) => attachment.url === "https://i.imgur.com/UkXMexG.mp4"
-      ),
-      channel: channel,
-    },
-  });
-
-  metrics.increment("new_post", 1);
-  await incrementStreakCount(user, channel, messageText, ts);
   return update;
 };
 

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -85,19 +85,13 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
   const convertedDate = new Date(date).toISOString();
   const messageText = await formatText(text);
 
-  const userInfo = app.client.users.info({
-    user: userRecord.slackID
-  });
-
   const updateInfo = {
     messageText,
     postTime: convertedDate,
     attachments,
-    userInfo,
+    userName: userRecord.slack.profile.display_name,
     channel
   };
-
- 
 
   const update = await prisma.updates.create({
     data: {

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -87,7 +87,7 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
 
   const updateInfo = {
     messageText,
-    postTime: convertedDate,
+    postTime: new Date(convertedDate).getTime(),
     attachments,
     userName: userRecord.slack.profile.display_name,
     channel

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -7,6 +7,18 @@ import { formatText, extractOgUrl, getAndUploadOgImage, getUrls, getPageContent 
 import { incrementStreakCount } from "./streaks.js";
 import { app } from "../app.js";
 import metrics from "../metrics.js";
+import { config } from "dotenv";
+import Airtable from "airtable";
+
+// load environment variables
+config()
+
+// initialize the airtable base
+const base = new Airtable({ 
+  apiKey: process.env.PLUGINS_AIRTABLE_API_KEY,
+}).base(process.env.PLUGINS_AIRTABLE_BASE_ID);
+
+
 
 export const createUpdate = async (files = [], channel, ts, user, text) => {
   let attachments = [];

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -122,7 +122,8 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
   // send a copy of the updates to the subcribers
   base("Update Listeners").select({
     maxRecords: 100,
-    view: "Grid view"
+    view: "Grid view",
+    filterByFormula: "NOT({Status} = 'Inactive')",
   }).eachPage((records, nextPage) => {
     records.forEach(async record => {
       const subcriber = { app: record.get("App"), endpoint: record.get("Endpoint"), status: record.get("Status") };

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/node@>=8.0.0 <15":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+
 "@types/node@^18.11.18":
   version "18.19.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.15.tgz#313a9d75435669a57fc28dc8694e7f4c4319f419"
@@ -359,6 +364,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+abortcontroller-polyfill@^1.4.0:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
+  integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
+
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -392,6 +402,17 @@ airtable-plus@^1.0.4:
     airtable "^0.7.2"
     camelcase-keys "^5.0.0"
     p-map "^2.0.0"
+
+airtable@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/airtable/-/airtable-0.12.2.tgz#e53e66db86744f9bc684faa58881d6c9c12f0e6f"
+  integrity sha512-HS3VytUBTKj8A0vPl7DDr5p/w3IOGv6RXL0fv7eczOWAtj9Xe8ri4TAiZRXoOyo+Z/COADCj+oARFenbxhmkIg==
+  dependencies:
+    "@types/node" ">=8.0.0 <15"
+    abort-controller "^3.0.0"
+    abortcontroller-polyfill "^1.4.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
 
 airtable@^0.7.2:
   version "0.7.2"


### PR DESCRIPTION
now services can subscribe to scrapbook updates.
an endpoint where the updates need to be sent are added in an airtable 
scrappy will send a copy of the update as a post request to that endpoint for it to consume