### PR TITLE
potentially fix og image extraction

### DIFF
--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -55,7 +55,7 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
         if (!ogUrls) continue;
 
         let imageUri = await getAndUploadOgImage(ogUrls);
-        if (!imageUri) {
+        if (imageUri) {
           attachments.push(imageUri);
           break;
         }


### PR DESCRIPTION
Someone tried to upload a GitHub link and scrappy deleted it :(

I'm pretty sure [this commit](https://github.com/hackclub/scrappy/pull/634/files#diff-72a2e73a7e262ae3d3ec867b49c7c9528744649f02c172d8354eb8188d489666R58) broke it.

This PR fixes the logic I think, but I haven't tested.

More: https://hackclub.slack.com/archives/C01NQTDFUR5/p1719182131326179