### PR TITLE
More robust error handling in og image extraction

### DIFF
--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -57,7 +57,6 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
         let imageUri = await getAndUploadOgImage(ogUrls);
         if (imageUri) {
           attachments.push(imageUri);
-          break;
         }
       } catch (error) {
         console.error(`Error processing URL ${url}:`, error);

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -57,6 +57,7 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
         let imageUri = await getAndUploadOgImage(ogUrls);
         if (imageUri) {
           attachments.push(imageUri);
+          break;
         }
       } catch (error) {
         console.error(`Error processing URL ${url}:`, error);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -100,21 +100,16 @@ export async function getPageContent(page) {
 }
 
 export async function getAndUploadOgImage(url) {
-  try {
-    const file = await fetch(url);
-    let blob = await file.blob();
-    const form = new FormData();
-    form.append("file", blob, `${uuidv4()}.png`);
+  const file = await fetch(url);
+  let blob = await file.blob();
+  const form = new FormData();
+  form.append("file", blob, `${uuidv4()}.png`);
 
-    const response = await fetch("https://bucky.hackclub.com", {
-      method: "POST",
-      body: form
-    });
+  const response = await fetch("https://bucky.hackclub.com", {
+    method: "POST",
+    body: form
+  });
 
-    const responseContent = await response.text();
-    return responseContent;
-  } catch (error) {
-    console.error('Error fetching or uploading file:', error);
-    return 'An error occurred';
-  }
+  const responseContent = await response.text();
+  return responseContent;
 }


### PR DESCRIPTION
Previously the `getAndUploadOgImage()` function always returned a string, even if there was an error. This PR allows it to throw because the code that calls it is already wrapped in a try/catch.

Follow-up to #639 