### PR TITLE
send metrics to grafana for when sending updates to scrapbook update 

### DIFF
--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -139,12 +139,16 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
           },
           body: JSON.stringify(updateInfo)
         });
-      } catch { } // silently fail to not crash app
+        metrics.increment("success.send_post_update", 1);
+      } catch { metrics.increment("errors.send_post_update", 1); } // silently fail to not crash app
 
     });
 
     // load the next set of documents
     nextPage();
+  }, (error) => {
+    if (error) metrics.increment("errors.airtable_get_post_listeners", 1);
+      metrics.increment("success.airtable_get_post_listeners", 1);
   });
 
   return update;


### PR DESCRIPTION
with this change, scrapbook will emit metrics when getting update listeners and when sending those metrics