### PR TITLE
add rate limiting to scrappy

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -61,7 +61,7 @@ export const app = new App({
 
 export const execute = (actionToExecute) => {
 
-  // console.log("Intercepting slack event");
+  console.log("Intercepting slack event");
   // // count the request
   // requestsCount += 1;
 

--- a/src/app.js
+++ b/src/app.js
@@ -29,29 +29,16 @@ const receiver = new ExpressReceiver({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
 });
 
+
 let requestCount = 0;
-const MAX_REQUESTS_PER_MINUTE = 1000;
+const MAX_REQUESTS_PER_MINUTE = process.env.MAX_REQUESTS_PER_MINUTE;
 setInterval(() => {
   // reset the request count
   requestCount = 0;
 }, 60 * 1000);
 
-function rateLimitMiddleware(request, response, next) {
-  console.log("requested url", request.url)
-  requestCount += 1;
-
-  console.log("Intercepting requests");
-  if (requestCount >= MAX_REQUESTS_PER_MINUTE) {
-    console.log("RATE LIMITING");
-    response.status(429).end();
-  }
-  // call next middleware in the stack if any
-  next();
-}
-
 receiver.router.use(bodyParser.urlencoded({ extended: true }));
 receiver.router.use(bodyParser.json());
-receiver.app.use(rateLimitMiddleware);
 
 export const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
@@ -60,12 +47,9 @@ export const app = new App({
 });
 
 export const execute = (actionToExecute) => {
+  requestsCount += 1;
 
-  console.log("Intercepting slack event");
-  // // count the request
-  // requestsCount += 1;
-
-  // if (requestsCount >= MAX_REQUESTS_PER_MINUTE) return async (_) => {}
+  if (requestsCount >= MAX_REQUESTS_PER_MINUTE) return async (_) => {}
 
   return async (slackObject, ...props) => {
     if (slackObject.ack) {


### PR DESCRIPTION
Add support for rate-limiting to scrappy as environment variable. 

Todo
- [ ] Set `MAX_REQUESTS_PER_MINUTE` as 240. 
Based on the average RPS on Heroku, scrappy gets about 4rps. Extending that to a minute gives us about 240. 
