### PR TITLE
delete scrapbook update if the message was deleted on slack client

### DIFF
--- a/src/events/create.js
+++ b/src/events/create.js
@@ -6,8 +6,12 @@ This is triggered when a new post shows up in the #scrapbook channel
 */
 
 import { createUpdate } from "../lib/updates.js";
+import deleted from "./deleted.js";
 
 export default async ({ event }) => {
+  // delete the scrapbook update if the message was deleted on slack client
+  if (event.subtype === "message_deleted") return await deleted({ event });
+
   if (event.thread_ts || event.channel != process.env.CHANNEL) return;
   const { files = [], channel, ts, user, text, thread_ts } = event;
   if (!thread_ts) await createUpdate(files, channel, ts, user, text);


### PR DESCRIPTION
previously if you posted a scrapbook update and then deleted it quickly before scrappy had a chance of finishing the scrapbooking process, it will still be posted on scrapbook even though the message was deleted from slack