### PR TITLE
add user email if absent

### DIFF
--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -60,18 +60,18 @@ export const getUserRecord = async (userId) => {
         data: { avatar: animalImage },
       });
     }
-  }
-
-  // update the user email if they don't have one on their account
-  if (!record.email) {
-    await prisma.accounts.update({
-      where: {
-        slackID: userId
-      },
-      data: {
-        email: user.profile.fields.email
+  } else {
+    // update the user email if they don't have one on their account
+      if (!record.email) {
+        await prisma.accounts.update({
+          where: {
+            slackID: userId
+          },
+          data: {
+            email: user.profile.email
+          }
+        })
       }
-    })
   }
 
   return { ...record, slack: user };

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -5,7 +5,7 @@ import { sample } from "./utils.js";
 export const getUserRecord = async (userId) => {
   let user
   try {
-    user = await app.client.users.profile.get({ user: userId });
+    user = await app.client.users.profile.get({ token: process.env.SLACK_USER_TOKEN, user: userId });
   }
   catch (e) {
     console.log(userId)

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -61,6 +61,19 @@ export const getUserRecord = async (userId) => {
       });
     }
   }
+
+  // update the user email if they don't have one on their account
+  if (!record.email) {
+    await prisma.accounts.update({
+      where: {
+        slackID: userId
+      },
+      data: {
+        email: user.profile.fields.email
+      }
+    })
+  }
+
   return { ...record, slack: user };
 };
 

--- a/src/lib/users.js
+++ b/src/lib/users.js
@@ -34,7 +34,7 @@ export const getUserRecord = async (userId) => {
         slackID: userId,
         username: `${username}${checkIfExists != null ? `-${userId}` : ""}`,
         streakCount: 0,
-        email: user.profile.fields.email,
+        email: user.profile.email,
         website: user.profile.fields["Xf5LNGS86L"]?.value || null,
         github: user.profile.fields["Xf0DMHFDQA"]?.value || null,
         newMember: true,


### PR DESCRIPTION
due to missing permissions, user emails where not set on scrapbook accounts. with this change, emails will be set everytime getUserRecord is called

addresses https://github.com/hackclub/scrapbook/issues/799