### PR TITLE
fix: parse argument to message sent by scrappy after setting css url

### DIFF
--- a/src/commands/setcss.js
+++ b/src/commands/setcss.js
@@ -30,7 +30,7 @@ export default async ({ command, respond }) => {
         where: { slackID: user.slackID },
         data: { cssURL: url },
       });
-      await respond(t("messages.css.set"));
+      await respond(t("messages.css.set", { url }));
     }
   }
 };


### PR DESCRIPTION
fixes #687 