### PR TITLE
ensure that the emoji is one of the streak count emojis

### DIFF
--- a/src/events/userChanged.js
+++ b/src/events/userChanged.js
@@ -8,7 +8,7 @@ export default async ({ event }) => {
   try {
     const { user } = event;
     const statusEmoji = user.profile.status_emoji;
-    if (statusEmoji?.includes("som-") && 
+    if (statusEmoji?.startsWith("som-") && 
     // the character that follows "som-" MUST be a numbe
     !Number.isNaN(parseInt(statusEmoji?.slice("som-".length)[0]))
   ) {

--- a/src/events/userChanged.js
+++ b/src/events/userChanged.js
@@ -8,7 +8,10 @@ export default async ({ event }) => {
   try {
     const { user } = event;
     const statusEmoji = user.profile.status_emoji;
-    if (statusEmoji?.includes("som-")) {
+    if (statusEmoji?.includes("som-") && 
+    // the character that follows "som-" MUST be a numbe
+    !Number.isNaN(parseInt(statusEmoji?.slice("som-".length)[0]))
+  ) {
       const statusEmojiCount = statusEmoji.split("-")[1].split(":")[0];
       const { streakCount } = await getUserRecord(user.id);
       if (


### PR DESCRIPTION
There are other emojis that follow the 'som-' pattern in slack and scrappy might be picking those up and falsely setting slack status as 🤡 .