### PR TITLE
upload images to AWS S3 instead of going through bucky.hackclub.com

### DIFF
--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -62,12 +62,10 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
       try {
         const pageContent = await getPageContent(url);
         const ogUrls = extractOgUrl(pageContent);
-        console.log("og urls", ogUrls);
 
         if (!ogUrls) continue;
 
         let imageUri = await getAndUploadOgImage(ogUrls);
-        console.log("image url", imageUri);
         if (imageUri) {
           attachments.push(imageUri);
           break;

--- a/src/lib/updates.js
+++ b/src/lib/updates.js
@@ -62,10 +62,12 @@ export const createUpdate = async (files = [], channel, ts, user, text) => {
       try {
         const pageContent = await getPageContent(url);
         const ogUrls = extractOgUrl(pageContent);
+        console.log("og urls", ogUrls);
 
         if (!ogUrls) continue;
 
         let imageUri = await getAndUploadOgImage(ogUrls);
+        console.log("image url", imageUri);
         if (imageUri) {
           attachments.push(imageUri);
           break;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -103,7 +103,7 @@ export async function getAndUploadOgImage(url) {
   const file = await fetch(url);
   let blob = await file.blob();
   const form = new FormData();
-  form.append("file", blob, `${uuidv4()}.png`);
+  form.append("file", blob, `${uuidv4()}.${blob.type.split("/")[1]}`);
 
   const response = await fetch("https://bucky.hackclub.com", {
     method: "POST",

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -129,13 +129,5 @@ export async function getAndUploadOgImage(url) {
 
   const imageUrl = await uploadImageToS3(`${uuidv4()}.${blob.type.split("/")[1]}`, blob);
 
-  // const response = await fetch("https://bucky.hackclub.com", {
-  //   method: "POST",
-  //   body: form
-  // });
-
-  // const responseContent = await response.text();
-  // return responseContent;
-  console.log("got image url", imageUrl);
   return imageUrl;
 }


### PR DESCRIPTION
upload images to AWS S3 instead of going through bucky.hackclub.com.

Images uploaded to bucky.hackclub.com are only valid for 24 hours which means scrapbook post that included OpenGraph images will look broken after a day of being posted as the OG image gets removed from s3. 

These image urls cannot be retroactively fixed but this change ensures that future OG images are uploaded directly to scrapbook's s3 bucket. 